### PR TITLE
core: Log user ringbuf drain return value

### DIFF
--- a/main.bpf.c
+++ b/main.bpf.c
@@ -1074,7 +1074,10 @@ void BPF_STRUCT_OPS(goland_dispatch, s32 cpu, struct task_struct *prev)
 	 * dispatch them on the target CPU decided by the user-space
 	 * scheduler.
 	 */
-	bpf_user_ringbuf_drain(&dispatched, handle_dispatched_task, NULL, BPF_RB_NO_WAKEUP);
+	s32 ret = bpf_user_ringbuf_drain(&dispatched,
+									 handle_dispatched_task, NULL, BPF_RB_NO_WAKEUP);
+	if (ret < 0)
+		dbg_msg("User ringbuf drain error: %d", ret);
 
 	/*
 	 * Consume a task from the per-CPU DSQ.


### PR DESCRIPTION
Record the return value of bpf_user_ringbuf_drain() in rustland_dispatch() to help debug and validate ringbuf behavior.

See: sched-ext/scx#2796