### PR TITLE
feat(scheduler): add fine-grained priority levels (0-20) for priority…

### DIFF
--- a/goland_core/priority_tasks.go
+++ b/goland_core/priority_tasks.go
@@ -14,14 +14,49 @@ import (
 	"fmt"
 )
 
+// Priority level constants
+const (
+	// PrioHighMin is the minimum (highest) priority for preemptive tasks
+	PrioHighMin = 0
+	// PrioHighMax is the maximum priority for preemptive tasks (0-9 can preempt)
+	PrioHighMax = 9
+	// PrioMedMin is the minimum priority for vtime-reduced tasks
+	PrioMedMin = 10
+	// PrioMedMax is the maximum priority for vtime-reduced tasks
+	PrioMedMax = 20
+)
+
 // UpdatePriorityTask adds or updates a task in the priority_tasks BPF map.
 // When a task is in this map, it will be prioritized during scheduling.
+// This function uses the default highest priority (0).
 // pid: the process ID of the task
 // slice: the time slice to assign to this priority task (in nanoseconds)
 func (s *Sched) UpdatePriorityTask(pid uint32, slice uint64) error {
 	ret := C.update_priority_task(C.u32(pid), C.u64(slice))
 	if ret != 0 {
 		return fmt.Errorf("failed to update priority task: pid=%d, ret=%d", pid, ret)
+	}
+	return nil
+}
+
+// UpdatePriorityTaskWithPrio adds or updates a task in the priority_tasks BPF map
+// with a specific priority level.
+//
+// Priority levels:
+//   - 0-9:   High priority - can preempt tasks with lower priority (higher number)
+//   - 10-20: Medium priority - gets vtime reduction but no preemption.
+//     Priority 10 gets 50% vtime reduction, priority 20 gets 5% reduction.
+//
+// pid: the process ID of the task
+// slice: the time slice to assign to this priority task (in nanoseconds)
+// prio: priority level (0-20), where lower is higher priority
+func (s *Sched) UpdatePriorityTaskWithPrio(pid uint32, slice uint64, prio uint32) error {
+	if prio > PrioMedMax {
+		return fmt.Errorf("invalid priority level: %d (must be 0-%d)", prio, PrioMedMax)
+	}
+	ret := C.update_priority_task_with_prio(C.u32(pid), C.u64(slice), C.u32(prio))
+	if ret != 0 {
+		return fmt.Errorf("failed to update priority task with prio: pid=%d, prio=%d, ret=%d", pid, prio, ret)
 	}
 	return nil
 }

--- a/wrapper.c
+++ b/wrapper.c
@@ -85,6 +85,16 @@ int update_priority_task(u32 pid, u64 slice) {
                                 BPF_ANY);
 }
 
+/*
+ * Note: There is a potential race condition in the two-step update process.
+ * When priority_tasks is updated first and then priority_tasks_prio, there's
+ * a brief window where the BPF code could observe a task in priority_tasks
+ * but not in priority_tasks_prio. During this window, the BPF code will
+ * default the task to priority 0 (highest priority with preemption).
+ * This is considered acceptable as it's a transient state and the BPF code
+ * handles missing priority gracefully. A more atomic approach is limited
+ * by BPF map API constraints.
+ */
 int update_priority_task_with_prio(u32 pid, u64 slice, u32 prio) {
     if (!global_obj || !global_obj->maps.priority_tasks || 
         !global_obj->maps.priority_tasks_prio)
@@ -106,16 +116,20 @@ int update_priority_task_with_prio(u32 pid, u64 slice, u32 prio) {
 int remove_priority_task(u32 pid) {
     if (!global_obj || !global_obj->maps.priority_tasks)
         return -1;
-    
+
+    int ret;
+
     /* Also remove from priority_tasks_prio if it exists */
     if (global_obj->maps.priority_tasks_prio) {
-        bpf_map__delete_elem(global_obj->maps.priority_tasks_prio, 
-                             &pid, sizeof(pid), 
-                             0);
+        ret = bpf_map__delete_elem(global_obj->maps.priority_tasks_prio,
+                                    &pid, sizeof(pid),
+                                    0);
+        if (ret != 0)
+            return ret;
     }
-    
-    return bpf_map__delete_elem(global_obj->maps.priority_tasks, 
-                                &pid, sizeof(pid), 
+
+    return bpf_map__delete_elem(global_obj->maps.priority_tasks,
+                                &pid, sizeof(pid),
                                 0);
 }
 

--- a/wrapper.c
+++ b/wrapper.c
@@ -85,9 +85,35 @@ int update_priority_task(u32 pid, u64 slice) {
                                 BPF_ANY);
 }
 
+int update_priority_task_with_prio(u32 pid, u64 slice, u32 prio) {
+    if (!global_obj || !global_obj->maps.priority_tasks || 
+        !global_obj->maps.priority_tasks_prio)
+        return -1;
+    
+    int ret = bpf_map__update_elem(global_obj->maps.priority_tasks, 
+                                   &pid, sizeof(pid), 
+                                   &slice, sizeof(slice), 
+                                   BPF_ANY);
+    if (ret != 0)
+        return ret;
+    
+    return bpf_map__update_elem(global_obj->maps.priority_tasks_prio, 
+                                &pid, sizeof(pid), 
+                                &prio, sizeof(prio), 
+                                BPF_ANY);
+}
+
 int remove_priority_task(u32 pid) {
     if (!global_obj || !global_obj->maps.priority_tasks)
         return -1;
+    
+    /* Also remove from priority_tasks_prio if it exists */
+    if (global_obj->maps.priority_tasks_prio) {
+        bpf_map__delete_elem(global_obj->maps.priority_tasks_prio, 
+                             &pid, sizeof(pid), 
+                             0);
+    }
+    
     return bpf_map__delete_elem(global_obj->maps.priority_tasks, 
                                 &pid, sizeof(pid), 
                                 0);

--- a/wrapper.h
+++ b/wrapper.h
@@ -79,6 +79,8 @@ void destroy_skel(void *);
 
 int update_priority_task(u32 pid, u64 slice);
 
+int update_priority_task_with_prio(u32 pid, u64 slice, u32 prio);
+
 int remove_priority_task(u32 pid);
 
 void set_scx_enums(


### PR DESCRIPTION
… tasks

Previously, priority tasks only had a binary distinction (priority vs non-priority). This change introduces a 21-level priority system for more granular control over task scheduling.

Priority level semantics:
- Levels 0-9 (high priority): can preempt tasks with lower priority
- Levels 10-20 (medium priority): receive vtime reduction (50% to 5%)

Changes:
- Add priority_tasks_prio BPF map to track priority levels
- Add can_preempt_by_prio() and calc_vtime_reduction() helpers
- Update enqueue logic in both kernel_mode and user-space mode
- Add UpdatePriorityTaskWithPrio() Go API
- Remove BPF-side map update functions (now managed by user-space)